### PR TITLE
<fix>: fix compile errors when use gcc compiler in Nix env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ else
 all: libsol.a
 endif
 CFLAGS += -Werror -Wall -Wextra -pedantic -Wshadow -Wcast-qual -Wcast-align -Wno-unused-parameter -Wno-gnu-folding-constant
+ifeq ($(EMULATOR),1)
 CFLAGS += -Wno-newline-eof -Wno-strict-prototypes
+endif
 CFLAGS += -Iinclude
 CFLAGS += $($(mode)_CFLAGS)
 CFLAGS += -ffunction-sections -fdata-sections $(CPUFLAGS) $(FPUFLAGS) 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ else
 all: libsol.a
 endif
 CFLAGS += -Werror -Wall -Wextra -pedantic -Wshadow -Wcast-qual -Wcast-align -Wno-unused-parameter -Wno-gnu-folding-constant
+CFLAGS += -Wno-newline-eof -Wno-strict-prototypes
 CFLAGS += -Iinclude
 CFLAGS += $($(mode)_CFLAGS)
 CFLAGS += -ffunction-sections -fdata-sections $(CPUFLAGS) $(FPUFLAGS) 


### PR DESCRIPTION
fix `-Wnewline-eof` and `-Wstrict-prototypes` when using gcc compiler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated build process to suppress specific compiler warnings during compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->