### PR TITLE
<fix>: fix "-Wstrict-prototypes" errors when using gcc compiler

### DIFF
--- a/instruction_test.c
+++ b/instruction_test.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 
-void test_instruction_program_id_system() {
+void test_instruction_program_id_system(void) {
     Pubkey program_id;
     memcpy(&program_id, &system_program_id, PUBKEY_SIZE);
     Instruction instruction = {0, NULL, 0, NULL, 0};
@@ -22,7 +22,7 @@ void test_instruction_program_id_system() {
     }
 }
 
-void test_instruction_program_id_stake() {
+void test_instruction_program_id_stake(void) {
     Pubkey program_id;
     memcpy(&program_id, &stake_program_id, PUBKEY_SIZE);
     Instruction instruction = {0, NULL, 0, NULL, 0};
@@ -36,7 +36,7 @@ void test_instruction_program_id_stake() {
     }
 }
 
-void test_instruction_program_id_unknown() {
+void test_instruction_program_id_unknown(void) {
     Pubkey program_id = {{BYTES32_BS58_2}};
     Instruction instruction = {0, NULL, 0, NULL, 0};
     {
@@ -49,7 +49,7 @@ void test_instruction_program_id_unknown() {
     }
 }
 
-void test_instruction_validate_ok() {
+void test_instruction_validate_ok(void) {
     uint8_t accounts[] = {1, 2, 3};
     Instruction instruction = {0, accounts, 3, NULL, 0};
     {
@@ -62,7 +62,7 @@ void test_instruction_validate_ok() {
     }
 }
 
-void test_instruction_validate_bad_program_id_index_fail() {
+void test_instruction_validate_bad_program_id_index_fail(void) {
     uint8_t accounts[] = {1, 2, 3};
     Instruction instruction = {4, accounts, 3, NULL, 0};
     {
@@ -75,7 +75,7 @@ void test_instruction_validate_bad_program_id_index_fail() {
     }
 }
 
-void test_instruction_validate_bad_first_account_index_fail() {
+void test_instruction_validate_bad_first_account_index_fail(void) {
     uint8_t accounts[] = {4, 2, 3};
     Instruction instruction = {0, accounts, 3, NULL, 0};
     {
@@ -88,7 +88,7 @@ void test_instruction_validate_bad_first_account_index_fail() {
     }
 }
 
-void test_instruction_validate_bad_last_account_index_fail() {
+void test_instruction_validate_bad_last_account_index_fail(void) {
     uint8_t accounts[] = {1, 2, 4};
     Instruction instruction = {0, accounts, 3, NULL, 0};
     {
@@ -101,7 +101,7 @@ void test_instruction_validate_bad_last_account_index_fail() {
     }
 }
 
-void test_static_brief_initializer_macros() {
+void test_static_brief_initializer_macros(void) {
     InstructionBrief system_test = SYSTEM_IX_BRIEF(SystemTransfer);
     InstructionBrief system_expect = {ProgramIdSystem, .system = SystemTransfer};
     assert(memcmp(&system_test, &system_expect, sizeof(InstructionBrief)) == 0);
@@ -110,7 +110,7 @@ void test_static_brief_initializer_macros() {
     assert(memcmp(&stake_test, &stake_expect, sizeof(InstructionBrief)) == 0);
 }
 
-void test_instruction_info_matches_brief() {
+void test_instruction_info_matches_brief(void) {
     InstructionInfo info = {
         .kind = ProgramIdSystem,
         .system =
@@ -125,7 +125,7 @@ void test_instruction_info_matches_brief() {
     assert(!instruction_info_matches_brief(&info, &brief_fail));
 }
 
-void test_instruction_infos_match_briefs() {
+void test_instruction_infos_match_briefs(void) {
     InstructionInfo infos[] = {{
                                    .kind = ProgramIdSystem,
                                    .system =
@@ -159,7 +159,7 @@ void test_instruction_infos_match_briefs() {
     assert(!instruction_infos_match_briefs(display_infos, bad_briefs, infos_len));
 }
 
-void test_instruction_accounts_iterator_next() {
+void test_instruction_accounts_iterator_next(void) {
     uint8_t instruction_accounts[] = {0, 1, 2};
     Instruction instruction = {
         2,
@@ -206,7 +206,7 @@ void test_instruction_accounts_iterator_next() {
     assert(instruction_accounts_iterator_remaining(&it) == expected_remaining);
 }
 
-int main() {
+int main(void) {
     test_instruction_validate_ok();
     test_instruction_validate_bad_program_id_index_fail();
     test_instruction_validate_bad_first_account_index_fail();

--- a/message_test.c
+++ b/message_test.c
@@ -9,7 +9,7 @@
 // Disable clang format for this file to keep clear buffer formatting
 /* clang-format off */
 
-void test_process_message_body_ok() {
+void test_process_message_body_ok(void) {
     Pubkey accounts[] = {
         {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},
         {{204, 241, 115, 109, 41, 173, 110, 48, 24, 113, 210, 213, 163, 78, 1, 112, 146, 114, 235, 220, 96, 185, 184, 85, 163, 27, 124, 48, 54, 250, 233, 54}},
@@ -28,7 +28,7 @@ void test_process_message_body_ok() {
     assert(num_kinds == 4);
 }
 
-void test_process_message_body_xfer_w_nonce_ok() {
+void test_process_message_body_xfer_w_nonce_ok(void) {
     Pubkey accounts[] = {
         {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},
         {{204, 241, 115, 109, 41, 173, 110, 48, 24, 113, 210, 213, 163, 78, 1, 112, 146, 114, 235, 220, 96, 185, 184, 85, 163, 27, 124, 48, 54, 250, 233, 54}},
@@ -49,12 +49,12 @@ void test_process_message_body_xfer_w_nonce_ok() {
     assert(num_kinds == 6);
 }
 
-void test_process_message_body_too_few_ix_fail() {
+void test_process_message_body_too_few_ix_fail(void) {
     PrintConfig print_config = { .header = {false, 0, {0, 0, 0, 0}, NULL, NULL, 0}, .expert_mode = true };
     assert(process_message_body(NULL, 0, &print_config) == 1);
 }
 
-void test_process_message_body_too_many_ix_fail() {
+void test_process_message_body_too_many_ix_fail(void) {
     Pubkey accounts[] = {
         {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},
         {{204, 241, 115, 109, 41, 173, 110, 48, 24, 113, 210, 213, 163, 78, 1, 112, 146, 114, 235, 220, 96, 185, 184, 85, 163, 27, 124, 48, 54, 250, 233, 54}},
@@ -75,12 +75,12 @@ void test_process_message_body_too_many_ix_fail() {
     assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &print_config) == 1);
 }
 
-void test_process_message_body_data_too_short_fail() {
+void test_process_message_body_data_too_short_fail(void) {
     PrintConfig print_config = { .header = {false, 0, {0, 0, 0, 0}, NULL, NULL, 1}, .expert_mode = true };
     assert(process_message_body(NULL, 0, &print_config) == 1);
 }
 
-void test_process_message_body_data_too_long_fail() {
+void test_process_message_body_data_too_long_fail(void) {
     Pubkey accounts[] = {
         {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},
         {{204, 241, 115, 109, 41, 173, 110, 48, 24, 113, 210, 213, 163, 78, 1, 112, 146, 114, 235, 220, 96, 185, 184, 85, 163, 27, 124, 48, 54, 250, 233, 54}},
@@ -95,13 +95,13 @@ void test_process_message_body_data_too_long_fail() {
     assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &print_config) == 1);
 }
 
-void test_process_message_body_bad_ix_account_index_fail() {
+void test_process_message_body_bad_ix_account_index_fail(void) {
     PrintConfig print_config = { .header = {false, 0, {0, 0, 0, 1}, NULL, NULL, 1}, .expert_mode = true };
     uint8_t msg_body[] = {1, 0, 0};
     assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &print_config) == 1);
 }
 
-void test_process_message_body_unknown_ix_enum_fail() {
+void test_process_message_body_unknown_ix_enum_fail(void) {
     Pubkey accounts[] = {
         {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},
         {{204, 241, 115, 109, 41, 173, 110, 48, 24, 113, 210, 213, 163, 78, 1, 112, 146, 114, 235, 220, 96, 185, 184, 85, 163, 27, 124, 48, 54, 250, 233, 54}},
@@ -115,7 +115,7 @@ void test_process_message_body_unknown_ix_enum_fail() {
     assert(process_message_body(msg_body, ARRAY_LEN(msg_body), &print_config) == 1);
 }
 
-void test_process_message_body_ix_with_unknown_program_id_fail() {
+void test_process_message_body_ix_with_unknown_program_id_fail(void) {
     Pubkey accounts[] = {
         {{171, 88, 202, 32, 185, 160, 182, 116, 130, 185, 73, 48, 13, 216, 170, 71, 172, 195, 165, 123, 87, 70, 130, 219, 5, 157, 240, 187, 26, 191, 158, 218}},
         {{204, 241, 115, 109, 41, 173, 110, 48, 24, 113, 210, 213, 163, 78, 1, 112, 146, 114, 235, 220, 96, 185, 184, 85, 163, 27, 124, 48, 54, 250, 233, 54}},
@@ -147,7 +147,7 @@ static void process_message_body_and_sanity_check(const uint8_t* message, size_t
     }
 }
 
-void test_process_message_body_nonced_stake_create_with_seed() {
+void test_process_message_body_nonced_stake_create_with_seed(void) {
     uint8_t message[] = {
         2, 1, 4,
         8,
@@ -195,7 +195,7 @@ void test_process_message_body_nonced_stake_create_with_seed() {
     process_message_body_and_sanity_check(message, sizeof(message), 13);
 }
 
-void test_process_message_body_create_stake_account() {
+void test_process_message_body_create_stake_account(void) {
     uint8_t message[] = {
         2, 0, 3,
         5,
@@ -231,7 +231,7 @@ void test_process_message_body_create_stake_account() {
     process_message_body_and_sanity_check(message, sizeof(message), 9);
 }
 
-void test_process_message_body_create_stake_account_no_lockup() {
+void test_process_message_body_create_stake_account_no_lockup(void) {
     uint8_t message[] = {
         2, 0, 3,
         5,
@@ -267,7 +267,7 @@ void test_process_message_body_create_stake_account_no_lockup() {
     process_message_body_and_sanity_check(message, sizeof(message), 7);
 }
 
-void test_process_message_body_nonced_stake_create_with_seed_checked() {
+void test_process_message_body_nonced_stake_create_with_seed_checked(void) {
     uint8_t message[] = {
         3, 2, 5,
         10,
@@ -312,7 +312,7 @@ void test_process_message_body_nonced_stake_create_with_seed_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 11);
 }
 
-void test_process_message_body_create_stake_account_checked() {
+void test_process_message_body_create_stake_account_checked(void) {
     uint8_t message[] = {
         3, 1, 4,
         7,
@@ -345,7 +345,7 @@ void test_process_message_body_create_stake_account_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 7); // no lockup
 }
 
-void test_process_message_body_create_nonce_account() {
+void test_process_message_body_create_nonce_account(void) {
     uint8_t message[] = {
         2, 0, 3,
         5,
@@ -377,7 +377,7 @@ void test_process_message_body_create_nonce_account() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_create_nonce_account_with_seed() {
+void test_process_message_body_create_nonce_account_with_seed(void) {
     uint8_t message[] = {
         1, 0, 3,
         5,
@@ -412,7 +412,7 @@ void test_process_message_body_create_nonce_account_with_seed() {
     process_message_body_and_sanity_check(message, sizeof(message), 7);
 }
 
-void test_process_message_body_create_vote_account() {
+void test_process_message_body_create_vote_account(void) {
     uint8_t message[] = {
         2, 0, 4,
         6,
@@ -448,7 +448,7 @@ void test_process_message_body_create_vote_account() {
     process_message_body_and_sanity_check(message, sizeof(message), 8);
 }
 
-void test_process_message_body_create_vote_account_with_seed() {
+void test_process_message_body_create_vote_account_with_seed(void) {
     uint8_t message[] = {
         1, 0, 4,
         6,
@@ -487,7 +487,7 @@ void test_process_message_body_create_vote_account_with_seed() {
     process_message_body_and_sanity_check(message, sizeof(message), 10);
 }
 
-void test_process_message_body_nonce_withdraw() {
+void test_process_message_body_nonce_withdraw(void) {
     uint8_t message[] = {
         1, 1, 3,
         6,
@@ -511,7 +511,7 @@ void test_process_message_body_nonce_withdraw() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_stake_withdraw() {
+void test_process_message_body_stake_withdraw(void) {
     uint8_t message[] = {
         1, 1, 3,
         6,
@@ -535,7 +535,7 @@ void test_process_message_body_stake_withdraw() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_vote_withdraw() {
+void test_process_message_body_vote_withdraw(void) {
     uint8_t message[] = {
         1, 1, 1,
         4,
@@ -557,7 +557,7 @@ void test_process_message_body_vote_withdraw() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_system_nonce_authorize() {
+void test_process_message_body_system_nonce_authorize(void) {
     uint8_t message[] = {
         1, 1, 1,
         3,
@@ -578,7 +578,7 @@ void test_process_message_body_system_nonce_authorize() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_stake_authorize_staker() {
+void test_process_message_body_stake_authorize_staker(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -601,7 +601,7 @@ void test_process_message_body_stake_authorize_staker() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_stake_authorize_withdrawer() {
+void test_process_message_body_stake_authorize_withdrawer(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -624,7 +624,7 @@ void test_process_message_body_stake_authorize_withdrawer() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_stake_authorize_withdrawer_with_custodian() {
+void test_process_message_body_stake_authorize_withdrawer_with_custodian(void) {
     uint8_t message[] = {
       3, 2, 2,
       5,
@@ -648,7 +648,7 @@ void test_process_message_body_stake_authorize_withdrawer_with_custodian() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_stake_authorize_both() {
+void test_process_message_body_stake_authorize_both(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -678,7 +678,7 @@ void test_process_message_body_stake_authorize_both() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_stake_authorize_staker_checked() {
+void test_process_message_body_stake_authorize_staker_checked(void) {
     uint8_t message[] = {
         2, 1, 2,
         5,
@@ -701,7 +701,7 @@ void test_process_message_body_stake_authorize_staker_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_stake_authorize_withdrawer_checked() {
+void test_process_message_body_stake_authorize_withdrawer_checked(void) {
     uint8_t message[] = {
         2, 1, 2,
         5,
@@ -724,7 +724,7 @@ void test_process_message_body_stake_authorize_withdrawer_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_stake_authorize_withdrawer_with_custodian_checked() {
+void test_process_message_body_stake_authorize_withdrawer_with_custodian_checked(void) {
     uint8_t message[] = {
       3, 2, 2,
       6,
@@ -748,7 +748,7 @@ void test_process_message_body_stake_authorize_withdrawer_with_custodian_checked
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_stake_authorize_both_checked() {
+void test_process_message_body_stake_authorize_both_checked(void) {
     uint8_t message[] = {
         3, 2, 2,
         6,
@@ -778,7 +778,7 @@ void test_process_message_body_stake_authorize_both_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_vote_authorize_voter() {
+void test_process_message_body_vote_authorize_voter(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -801,7 +801,7 @@ void test_process_message_body_vote_authorize_voter() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_vote_authorize_withdrawer() {
+void test_process_message_body_vote_authorize_withdrawer(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -824,7 +824,7 @@ void test_process_message_body_vote_authorize_withdrawer() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_vote_authorize_both() {
+void test_process_message_body_vote_authorize_both(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -855,7 +855,7 @@ void test_process_message_body_vote_authorize_both() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_vote_authorize_voter_checked() {
+void test_process_message_body_vote_authorize_voter_checked(void) {
     uint8_t message[] = {
         2, 1, 2,
         5,
@@ -878,7 +878,7 @@ void test_process_message_body_vote_authorize_voter_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_vote_authorize_withdrawer_checked() {
+void test_process_message_body_vote_authorize_withdrawer_checked(void) {
     uint8_t message[] = {
         2, 1, 2,
         5,
@@ -901,7 +901,7 @@ void test_process_message_body_vote_authorize_withdrawer_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_vote_authorize_both_checked() {
+void test_process_message_body_vote_authorize_both_checked(void) {
     uint8_t message[] = {
         2, 1, 2,
         6,
@@ -932,7 +932,7 @@ void test_process_message_body_vote_authorize_both_checked() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_vote_update_node_v1_0_7() {
+void test_process_message_body_vote_update_node_v1_0_7(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -966,7 +966,7 @@ void test_process_message_body_vote_update_node_v1_0_7() {
     assert_string_equal(G_transaction_summary_text, expected);
 }
 
-void test_process_message_body_vote_update_node_v1_0_8() {
+void test_process_message_body_vote_update_node_v1_0_8(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -999,7 +999,7 @@ void test_process_message_body_vote_update_node_v1_0_8() {
     assert_string_equal(G_transaction_summary_text, expected);
 }
 
-void test_process_message_body_vote_update_commission() {
+void test_process_message_body_vote_update_commission(void) {
     uint8_t message[] = {
         2, 1, 1,
         3,
@@ -1019,7 +1019,7 @@ void test_process_message_body_vote_update_commission() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_stake_delegate() {
+void test_process_message_body_stake_delegate(void) {
     uint8_t message[] = {
         2, 1, 5,
         7,
@@ -1042,7 +1042,7 @@ void test_process_message_body_stake_delegate() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_stake_delegate_with_nonce() {
+void test_process_message_body_stake_delegate_with_nonce(void) {
     uint8_t message[] = {
         1, 1, 7,
         10,
@@ -1074,7 +1074,7 @@ void test_process_message_body_stake_delegate_with_nonce() {
     process_message_body_and_sanity_check(message, sizeof(message), 6);
 }
 
-void test_process_message_body_create_stake_account_and_delegate() {
+void test_process_message_body_create_stake_account_and_delegate(void) {
     uint8_t message[] = {
         3, 1, 7,
         10,
@@ -1121,7 +1121,7 @@ void test_process_message_body_create_stake_account_and_delegate() {
     process_message_body_and_sanity_check(message, sizeof(message), 11);
 }
 
-void test_process_message_body_create_stake_with_seed_account_and_delegate() {
+void test_process_message_body_create_stake_with_seed_account_and_delegate(void) {
     uint8_t message[] = {
         2, 0, 7,
         10,
@@ -1170,7 +1170,7 @@ void test_process_message_body_create_stake_with_seed_account_and_delegate() {
     process_message_body_and_sanity_check(message, sizeof(message), 13);
 }
 
-void test_process_message_body_stake_deactivate() {
+void test_process_message_body_stake_deactivate(void) {
     uint8_t message[] = {
         1, 1, 2,
         4,
@@ -1190,7 +1190,7 @@ void test_process_message_body_stake_deactivate() {
     process_message_body_and_sanity_check(message, sizeof(message), 3);
 }
 
-void test_process_message_body_stake_set_lockup() {
+void test_process_message_body_stake_set_lockup(void) {
     uint8_t message[] = {
         1, 1, 1,
         3,
@@ -1215,7 +1215,7 @@ void test_process_message_body_stake_set_lockup() {
     process_message_body_and_sanity_check(message, sizeof(message), 6);
 }
 
-void test_process_message_body_stake_set_lockup_checked() {
+void test_process_message_body_stake_set_lockup_checked(void) {
     uint8_t message[] = {
         2, 1, 1,
         4,
@@ -1240,7 +1240,7 @@ void test_process_message_body_stake_set_lockup_checked() {
 }
 
 // Using a nonce here to test worst case instruction usage as well
-void test_process_message_body_stake_split_with_nonce_v1_1() {
+void test_process_message_body_stake_split_with_nonce_v1_1(void) {
     uint8_t message[] = {
         3, 2, 3,
         8,
@@ -1287,7 +1287,7 @@ void test_process_message_body_stake_split_with_nonce_v1_1() {
 }
 
 // Using a nonce here to test worst case instruction usage as well
-void test_process_message_body_stake_split_with_nonce_v1_2() {
+void test_process_message_body_stake_split_with_nonce_v1_2(void) {
     uint8_t message[] = {
         3, 1, 3,
         8,
@@ -1328,7 +1328,7 @@ void test_process_message_body_stake_split_with_nonce_v1_2() {
     process_message_body_and_sanity_check(message, sizeof(message), 7);
 }
 
-void test_process_message_body_stake_split_with_seed_v1_1() {
+void test_process_message_body_stake_split_with_seed_v1_1(void) {
     uint8_t message[] = {
         1, 1, 2,
         5,
@@ -1362,7 +1362,7 @@ void test_process_message_body_stake_split_with_seed_v1_1() {
     process_message_body_and_sanity_check(message, sizeof(message), 7);
 }
 
-void test_process_message_body_stake_split_with_seed_v1_2() {
+void test_process_message_body_stake_split_with_seed_v1_2(void) {
     uint8_t message[] = {
         2, 0, 2,
         5,
@@ -1396,7 +1396,7 @@ void test_process_message_body_stake_split_with_seed_v1_2() {
     process_message_body_and_sanity_check(message, sizeof(message), 7);
 }
 
-void test_process_message_body_stake_merge() {
+void test_process_message_body_stake_merge(void) {
     uint8_t message[] = {
         0x01, 0x00, 0x03,
         0x06,
@@ -1437,7 +1437,7 @@ void test_process_message_body_stake_merge() {
 #define DELEGATE        DEST_ACCOUNT
 #define NEW_OWNER       DEST_ACCOUNT
 
-void test_process_message_body_spl_token_create_token() {
+void test_process_message_body_spl_token_create_token(void) {
     uint8_t message[] = {
         2, 0, 3,
         5,
@@ -1468,7 +1468,7 @@ void test_process_message_body_spl_token_create_token() {
     process_message_body_and_sanity_check(message, sizeof(message), 6);
 }
 
-void test_process_message_body_spl_token_create_account() {
+void test_process_message_body_spl_token_create_account(void) {
     uint8_t message[] = {
         0x02, 0x00, 0x03,
         0x06,
@@ -1499,7 +1499,7 @@ void test_process_message_body_spl_token_create_account() {
     process_message_body_and_sanity_check(message, sizeof(message), 6);
 }
 
-void test_process_message_body_spl_token_create_account2() {
+void test_process_message_body_spl_token_create_account2(void) {
     uint8_t message[] = {
         0x02, 0x00, 0x04,
         0x06,
@@ -1531,7 +1531,7 @@ void test_process_message_body_spl_token_create_account2() {
     process_message_body_and_sanity_check(message, sizeof(message), 6);
 }
 
-void test_process_message_body_spl_token_create_multisig() {
+void test_process_message_body_spl_token_create_multisig(void) {
     uint8_t message[] = {
         2, 0, 5,
         8,
@@ -1565,7 +1565,7 @@ void test_process_message_body_spl_token_create_multisig() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_spl_token_transfer() {
+void test_process_message_body_spl_token_transfer(void) {
     uint8_t message[] = {
         1, 0, 2,
         5,
@@ -1587,7 +1587,7 @@ void test_process_message_body_spl_token_transfer() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_spl_token_approve() {
+void test_process_message_body_spl_token_approve(void) {
     uint8_t message[] = {
         1, 0, 2,
         5,
@@ -1609,7 +1609,7 @@ void test_process_message_body_spl_token_approve() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_spl_token_revoke() {
+void test_process_message_body_spl_token_revoke(void) {
     uint8_t message[] = {
         1, 0, 2,
         3,
@@ -1627,7 +1627,7 @@ void test_process_message_body_spl_token_revoke() {
     process_message_body_and_sanity_check(message, sizeof(message), 3);
 }
 
-void test_process_message_body_spl_token_set_authority() {
+void test_process_message_body_spl_token_set_authority(void) {
     uint8_t message[] = {
         1, 0, 1,
         3,
@@ -1648,7 +1648,7 @@ void test_process_message_body_spl_token_set_authority() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_spl_token_mint_to() {
+void test_process_message_body_spl_token_mint_to(void) {
     uint8_t message[] = {
         1, 0, 0,
         4,
@@ -1669,7 +1669,7 @@ void test_process_message_body_spl_token_mint_to() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_spl_token_burn() {
+void test_process_message_body_spl_token_burn(void) {
     uint8_t message[] = {
         1, 0, 0,
         4,
@@ -1690,7 +1690,7 @@ void test_process_message_body_spl_token_burn() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_spl_token_close_account() {
+void test_process_message_body_spl_token_close_account(void) {
     uint8_t message[] = {
         0x01, 0x00, 0x01,
         0x03,
@@ -1709,7 +1709,7 @@ void test_process_message_body_spl_token_close_account() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_spl_token_freeze_account() {
+void test_process_message_body_spl_token_freeze_account(void) {
     uint8_t message[] = {
         1, 0, 2,
         4,
@@ -1728,7 +1728,7 @@ void test_process_message_body_spl_token_freeze_account() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_spl_token_thaw_account() {
+void test_process_message_body_spl_token_thaw_account(void) {
     uint8_t message[] = {
         1, 0, 2,
         4,
@@ -1747,7 +1747,7 @@ void test_process_message_body_spl_token_thaw_account() {
     process_message_body_and_sanity_check(message, sizeof(message), 4);
 }
 
-void test_process_message_body_spl_associated_token_create() {
+void test_process_message_body_spl_associated_token_create(void) {
     uint8_t message[] = {
         0x01, 0x00, 0x05,
         0x06,
@@ -1769,7 +1769,7 @@ void test_process_message_body_spl_associated_token_create() {
 }
 
 // old version of ata create that accessed the rent sysvar via account load
-void test_process_message_body_spl_associated_token_create_deprecated() {
+void test_process_message_body_spl_associated_token_create_deprecated(void) {
     uint8_t message[] = {
         0x01, 0x00, 0x05,
         0x07,
@@ -1791,7 +1791,7 @@ void test_process_message_body_spl_associated_token_create_deprecated() {
     process_message_body_and_sanity_check(message, sizeof(message), 5);
 }
 
-void test_process_message_body_spl_associated_token_create_with_transfer() {
+void test_process_message_body_spl_associated_token_create_with_transfer(void) {
     uint8_t message[] = {
         0x02, 0x00, 0x05,
         0x09,
@@ -1822,7 +1822,7 @@ void test_process_message_body_spl_associated_token_create_with_transfer() {
     process_message_body_and_sanity_check(message, sizeof(message), 9);
 }
 
-void test_process_message_body_spl_associated_token_create_with_transfer_and_assert_owner() {
+void test_process_message_body_spl_associated_token_create_with_transfer_and_assert_owner(void) {
     uint8_t message[] = {
             0x01, 0x00, 0x07,
             0x0a,
@@ -1863,7 +1863,7 @@ void test_process_message_body_spl_associated_token_create_with_transfer_and_ass
 
 /* clang-format on */
 
-int main() {
+int main(void) {
     test_process_message_body_spl_associated_token_create_with_transfer_and_assert_owner();
     test_process_message_body_spl_associated_token_create_with_transfer();
     test_process_message_body_spl_associated_token_create();

--- a/parser_test.c
+++ b/parser_test.c
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <assert.h>
 
-void test_parse_u8() {
+void test_parse_u8(void) {
     uint8_t message[] = {1, 2};
     Parser parser = {message, sizeof(message)};
     uint8_t value;
@@ -15,7 +15,7 @@ void test_parse_u8() {
     assert(value == 1);
 }
 
-void test_parse_u8_too_short() {
+void test_parse_u8_too_short(void) {
     uint8_t message[] = {42};
     Parser parser = {message, sizeof(message)};
     uint8_t value;
@@ -23,7 +23,7 @@ void test_parse_u8_too_short() {
     assert(parse_u8(&parser, &value) == 1);
 }
 
-void test_parse_u16() {
+void test_parse_u16(void) {
     uint8_t message[] = {0, 0, 255, 255};
     Parser parser = {message, sizeof(message)};
     uint16_t value;
@@ -34,7 +34,7 @@ void test_parse_u16() {
     assert(parser_is_empty(&parser));
 }
 
-void test_parse_u32() {
+void test_parse_u32(void) {
     uint8_t message[] = {0, 0, 0, 0, 255, 255, 255, 255};
     Parser parser = {message, sizeof(message)};
     uint32_t value;
@@ -45,7 +45,7 @@ void test_parse_u32() {
     assert(parser_is_empty(&parser));
 }
 
-void test_parse_u64() {
+void test_parse_u64(void) {
     uint8_t message[] = {0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255};
     Parser parser = {message, sizeof(message)};
     uint64_t value;
@@ -56,7 +56,7 @@ void test_parse_u64() {
     assert(parser_is_empty(&parser));
 }
 
-void test_parse_i64() {
+void test_parse_i64(void) {
     uint8_t buffer[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f};
     Parser parser = {buffer, sizeof(buffer)};
@@ -69,7 +69,7 @@ void test_parse_i64() {
     assert(value == INT64_MAX);
 }
 
-void test_parse_length() {
+void test_parse_length(void) {
     uint8_t message[] = {1, 2};
     Parser parser = {message, sizeof(message)};
     size_t value;
@@ -79,7 +79,7 @@ void test_parse_length() {
     assert(value == 1);
 }
 
-void test_parser_option() {
+void test_parser_option(void) {
     uint8_t message[] = {0x00, 0x01, 0x02, 0xff};
     Parser parser = {message, sizeof(message)};
     enum Option value;
@@ -96,7 +96,7 @@ void test_parser_option() {
     assert(parse_option(&parser, &value) == 1);
 }
 
-void test_parse_sized_string() {
+void test_parse_sized_string(void) {
     SizedString value;
     uint8_t buffer[] = {/* "test" */
                         0x04,
@@ -148,7 +148,7 @@ void test_parse_sized_string() {
     assert(parse_sized_string(&parser, &value) == 1);
 }
 
-void test_parse_pubkey() {
+void test_parse_pubkey(void) {
     const Pubkey* value;
     const char* expected_string = "11111111111111111111111111111111";
     char value_string[BASE58_PUBKEY_LENGTH];
@@ -225,7 +225,7 @@ void test_parse_pubkey() {
     assert(parse_pubkey(&parser, &value) == 1);
 }
 
-void test_parse_length_two_bytes() {
+void test_parse_length_two_bytes(void) {
     uint8_t message[] = {128, 1};
     Parser parser = {message, sizeof(message)};
     size_t value;
@@ -235,7 +235,7 @@ void test_parse_length_two_bytes() {
     assert(value == 128);
 }
 
-void test_parse_pubkeys_header() {
+void test_parse_pubkeys_header(void) {
     uint8_t message[] = {1, 2, 3, 4};
     Parser parser = {message, sizeof(message)};
     PubkeysHeader header;
@@ -245,7 +245,7 @@ void test_parse_pubkeys_header() {
     assert(header.pubkeys_length == 4);
 }
 
-void test_parse_pubkeys() {
+void test_parse_pubkeys(void) {
     uint8_t message[PUBKEY_SIZE + 4] = {1, 2, 3, 1, 42};
     Parser parser = {message, sizeof(message)};
     PubkeysHeader header;
@@ -256,7 +256,7 @@ void test_parse_pubkeys() {
     assert(pubkeys->data[0] == 42);
 }
 
-void test_parse_pubkeys_too_short() {
+void test_parse_pubkeys_too_short(void) {
     uint8_t message[] = {1, 2, 3, 1};
     Parser parser = {message, sizeof(message)};
     PubkeysHeader header;
@@ -264,7 +264,7 @@ void test_parse_pubkeys_too_short() {
     assert(parse_pubkeys(&parser, &header, &pubkeys) == 1);
 }
 
-void test_parse_hash() {
+void test_parse_hash(void) {
     uint8_t message[HASH_SIZE] = {42};
     Parser parser = {message, sizeof(message)};
     const Hash* hash;
@@ -274,14 +274,14 @@ void test_parse_hash() {
     assert(hash->data[0] == 42);
 }
 
-void test_parse_hash_too_short() {
+void test_parse_hash_too_short(void) {
     uint8_t message[31];  // <--- Too short!
     Parser parser = {message, sizeof(message)};
     const Hash* hash;
     assert(parse_hash(&parser, &hash) == 1);
 }
 
-void test_parse_data() {
+void test_parse_data(void) {
     uint8_t message[] = {1, 2};
     Parser parser = {message, sizeof(message)};
     const uint8_t* data;
@@ -292,7 +292,7 @@ void test_parse_data() {
     assert(data[0] == 2);
 }
 
-void test_parse_data_too_short() {
+void test_parse_data_too_short(void) {
     uint8_t message[] = {1};  // <--- Too short!
     Parser parser = {message, sizeof(message)};
     const uint8_t* data;
@@ -300,7 +300,7 @@ void test_parse_data_too_short() {
     assert(parse_data(&parser, &data, &data_length) == 1);
 }
 
-void test_parse_instruction() {
+void test_parse_instruction(void) {
     uint8_t message[] = {0, 2, 33, 34, 1, 36};
     Parser parser = {message, sizeof(message)};
     Instruction instruction;
@@ -312,7 +312,7 @@ void test_parse_instruction() {
     assert(instruction.data[0] == 36);
 }
 
-void test_parser_is_empty() {
+void test_parser_is_empty(void) {
     uint8_t buf[1] = {0};
     Parser nonempty = {buf, 1};
     assert(!parser_is_empty(&nonempty));
@@ -320,7 +320,7 @@ void test_parser_is_empty() {
     assert(parser_is_empty(&empty));
 }
 
-int main() {
+int main(void) {
     test_parse_u8();
     test_parse_u8_too_short();
     test_parse_u16();

--- a/print_config_test.c
+++ b/print_config_test.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-void test_print_config_show_authority() {
+void test_print_config_show_authority(void) {
     Pubkey signer = {{BYTES32_BS58_1}};
     Pubkey not_signer = {{BYTES32_BS58_2}};
     PrintConfig print_config = {.expert_mode = false, .signer_pubkey = &signer};
@@ -15,7 +15,7 @@ void test_print_config_show_authority() {
     assert(print_config_show_authority(&print_config, &not_signer));
 }
 
-int main() {
+int main(void) {
     test_print_config_show_authority();
 
     printf("passed\n");

--- a/printer_test.c
+++ b/printer_test.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-void test_print_amount() {
+void test_print_amount(void) {
     char printed[24];
 
     print_amount(0, printed, sizeof(printed));
@@ -19,7 +19,7 @@ void test_print_amount() {
     assert_string_equal(printed, "10000000.1 SOL");
 }
 
-void test_print_token_amount() {
+void test_print_token_amount(void) {
     char printed[26];
 
     print_token_amount(0, "TST", 0, printed, sizeof(printed));
@@ -46,7 +46,7 @@ void test_print_token_amount() {
     assert_string_equal(printed, "18446744073709551615 TST");
 }
 
-void test_print_sized_string() {
+void test_print_sized_string(void) {
     char buf[5];
     const char test[] = {0x74, 0x65, 0x73, 0x74};
     SizedString string = {sizeof(test), test};
@@ -64,7 +64,7 @@ void test_print_sized_string() {
     assert_string_equal(buf, "");
 }
 
-void test_print_string() {
+void test_print_string(void) {
     char buf[5];
 
     assert(print_string("fits", buf, sizeof(buf)) == 0);
@@ -77,7 +77,7 @@ void test_print_string() {
     assert_string_equal("", buf);
 }
 
-void test_print_summary() {
+void test_print_summary(void) {
     char summary[27];
     assert(print_summary("GADFVW3UXVKDOU626XUPYDJU2BFCGFJHQ6SREYOZ6IJV4XSHOALEQN2I",
                          summary,
@@ -99,7 +99,7 @@ void test_print_summary() {
     assert(print_summary("buffer too small", NULL, 0, 12, 12) == 1);
 }
 
-void test_print_i64() {
+void test_print_i64(void) {
     char buf[21];
     assert(print_i64(INT64_MIN, buf, sizeof(buf)) == 0);
     assert_string_equal(buf, "-9223372036854775808");
@@ -111,7 +111,7 @@ void test_print_i64() {
     assert_string_equal(buf, "-1");
 }
 
-void test_print_u64() {
+void test_print_u64(void) {
 #define U64_MAX_STR (20 + 1)  // strlen("18446744073709551615") + NUL
     char out[U64_MAX_STR];
 
@@ -124,7 +124,7 @@ void test_print_u64() {
     assert(print_u64(0, NULL, 0) == 1);
 }
 
-void test_print_timestamp() {
+void test_print_timestamp(void) {
 #define RFC3339_MAX (4 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1 + 2 + 1)
     char out[RFC3339_MAX];
     int64_t unix_epoch = 0;
@@ -142,7 +142,7 @@ void test_print_timestamp() {
     assert(print_timestamp(0, out, sizeof(out) - 1) == 1);
 }
 
-int main() {
+int main(void) {
     test_print_amount();
     test_print_token_amount();
     test_print_sized_string();

--- a/rfc3339_test.c
+++ b/rfc3339_test.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-void test_rfc3339_format() {
+void test_rfc3339_format(void) {
     char s[20];
 
     // Buffer too small fails
@@ -25,7 +25,7 @@ void test_rfc3339_format() {
     assert_string_equal(s, "9999-12-31 23:59:59");
 }
 
-int main() {
+int main(void) {
     test_rfc3339_format();
 
     printf("passed\n");

--- a/serum_assert_owner_instruction_test.c
+++ b/serum_assert_owner_instruction_test.c
@@ -4,7 +4,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-void test_is_serum_assert_owner_program_id() {
+void test_is_serum_assert_owner_program_id(void) {
     const Pubkey serum_deployment = {{PROGRAM_ID_SERUM_ASSERT_OWNER}};
     const Pubkey phantom_deployment = {{PROGRAM_ID_SERUM_ASSERT_OWNER_PHANTOM}};
 
@@ -13,7 +13,7 @@ void test_is_serum_assert_owner_program_id() {
     assert(!is_serum_assert_owner_program_id(&system_program_id));
 }
 
-int main() {
+int main(void) {
     test_is_serum_assert_owner_program_id();
 
     printf("passed\n");

--- a/spl_token_instruction_test.c
+++ b/spl_token_instruction_test.c
@@ -22,7 +22,7 @@ void print_pubkey(const Pubkey* pubkey) {
 #define DELEGATE         DEST_ACCOUNT
 #define NEW_OWNER        DEST_ACCOUNT
 
-void test_parse_spl_token_create_token() {
+void test_parse_spl_token_create_token(void) {
     uint8_t message[] = {2,
                          0,
                          3,
@@ -99,7 +99,7 @@ void test_parse_spl_token_create_token() {
     assert(init_mint->freeze_authority == NULL);
 }
 
-void test_parse_spl_token_create_account() {
+void test_parse_spl_token_create_account(void) {
     uint8_t message[] = {
         0x02,
         0x00,
@@ -178,7 +178,7 @@ void test_parse_spl_token_create_account() {
     assert_pubkey_equal(init_acc->owner, &owner);
 }
 
-void test_parse_spl_token_create_account2() {
+void test_parse_spl_token_create_account2(void) {
     uint8_t message[] = {0x02,
                          0x00,
                          0x04,
@@ -255,7 +255,7 @@ void test_parse_spl_token_create_account2() {
     assert_pubkey_equal(init_acc->owner, &owner);
 }
 
-void test_parse_spl_token_create_multisig() {
+void test_parse_spl_token_create_multisig(void) {
     uint8_t message[] = {2,
                          0,
                          5,
@@ -340,7 +340,7 @@ void test_parse_spl_token_create_multisig() {
     assert_pubkey_equal(signer++, &signer3);
 }
 
-void test_parse_spl_token_transfer() {
+void test_parse_spl_token_transfer(void) {
     uint8_t message[] = {1,
                          0,
                          2,
@@ -400,7 +400,7 @@ void test_parse_spl_token_transfer() {
     assert_pubkey_equal(tr_info->mint_account, &mint_account);
 }
 
-void test_parse_spl_token_approve() {
+void test_parse_spl_token_approve(void) {
     uint8_t message[] = {1,
                          0,
                          2,
@@ -459,7 +459,7 @@ void test_parse_spl_token_approve() {
     assert_pubkey_equal(ap_info->mint_account, &mint_account);
 }
 
-void test_parse_spl_token_revoke() {
+void test_parse_spl_token_revoke(void) {
     uint8_t message[] = {1,
                          0,
                          2,
@@ -497,7 +497,7 @@ void test_parse_spl_token_revoke() {
     assert_pubkey_equal(re_info->sign.single.signer, &owner);
 }
 
-void test_parse_spl_token_set_authority() {
+void test_parse_spl_token_set_authority(void) {
     uint8_t message[] = {1,
                          0,
                          1,
@@ -543,7 +543,7 @@ void test_parse_spl_token_set_authority() {
     assert_pubkey_equal(so_info->sign.single.signer, &owner);
 }
 
-void test_parse_spl_token_mint_to() {
+void test_parse_spl_token_mint_to(void) {
     uint8_t message[] = {1,
                          0,
                          0,
@@ -597,7 +597,7 @@ void test_parse_spl_token_mint_to() {
     assert_pubkey_equal(mt_info->sign.single.signer, &owner);
 }
 
-void test_parse_spl_token_burn() {
+void test_parse_spl_token_burn(void) {
     uint8_t message[] = {1,
                          0,
                          0,
@@ -652,7 +652,7 @@ void test_parse_spl_token_burn() {
     assert_pubkey_equal(bn_info->mint_account, &mint_account);
 }
 
-void test_parse_spl_token_close_account() {
+void test_parse_spl_token_close_account(void) {
     uint8_t message[] = {
         0x01,
         0x00,
@@ -696,7 +696,7 @@ void test_parse_spl_token_close_account() {
     assert_pubkey_equal(close_acc->sign.single.signer, &owner);
 }
 
-void test_parse_spl_token_freeze_account() {
+void test_parse_spl_token_freeze_account(void) {
     uint8_t message[] = {1,
                          0,
                          2,
@@ -739,7 +739,7 @@ void test_parse_spl_token_freeze_account() {
     assert_pubkey_equal(freeze_account->sign.single.signer, &owner);
 }
 
-void test_parse_spl_token_thaw_account() {
+void test_parse_spl_token_thaw_account(void) {
     uint8_t message[] = {1,
                          0,
                          2,
@@ -782,7 +782,7 @@ void test_parse_spl_token_thaw_account() {
     assert_pubkey_equal(thaw_account->sign.single.signer, &owner);
 }
 
-void test_parse_spl_token_sync_native() {
+void test_parse_spl_token_sync_native(void) {
     uint8_t message[] = {1,
                          0,
                          1,
@@ -816,7 +816,7 @@ void test_parse_spl_token_sync_native() {
     assert_pubkey_equal(sync_native->token_account, &token_account);
 }
 
-void test_parse_spl_token_instruction_kind() {
+void test_parse_spl_token_instruction_kind(void) {
     SplTokenInstructionKind kind;
 
     uint8_t buf[] = {0};
@@ -936,7 +936,7 @@ void test_parse_spl_token_instruction_kind() {
     assert(parse_spl_token_instruction_kind(&parser, &kind) == 1);
 }
 
-void test_parse_spl_token_sign() {
+void test_parse_spl_token_sign(void) {
     const size_t max_signers = Token_MAX_SIGNERS;
     const size_t max_accounts = 1 + max_signers;   // multisig_account + signers
     const size_t accounts_len = max_accounts + 1;  // one too many
@@ -985,7 +985,7 @@ void test_parse_spl_token_sign() {
     assert(sign.multi.signers.count == max_signers);
 }
 
-void test_print_m_of_n_string() {
+void test_print_m_of_n_string(void) {
     char s[M_OF_N_MAX_LEN];
 
     // n too big fails
@@ -1005,7 +1005,7 @@ void test_print_m_of_n_string() {
     assert_string_equal(s, "11 of 11");
 }
 
-int main() {
+int main(void) {
     test_print_m_of_n_string();
     test_parse_spl_token_sign();
     test_parse_spl_token_instruction_kind();

--- a/stake_instruction_test.c
+++ b/stake_instruction_test.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <assert.h>
 
-void test_parse_delegate_stake_instructions() {
+void test_parse_delegate_stake_instructions(void) {
     uint8_t message[] = {
         1,   1,   5,   7,   204, 241, 115, 109, 41,  173, 110, 48,  24,  113, 210, 213, 163, 78,
         1,   112, 146, 114, 235, 220, 96,  185, 184, 85,  163, 27,  124, 48,  54,  250, 233, 54,
@@ -35,7 +35,7 @@ void test_parse_delegate_stake_instructions() {
     assert(parser.buffer_length == 0);
 }
 
-void test_parse_stake_initialize_instruction() {
+void test_parse_stake_initialize_instruction(void) {
 #define ACCOUNT_PUBKEY_BYTES      BYTES32_BS58_2
 #define ST_AUTHORITY_PUBKEY_BYTES BYTES32_BS58_3
 #define WD_AUTHORITY_PUBKEY_BYTES BYTES32_BS58_4
@@ -109,7 +109,7 @@ void test_parse_stake_initialize_instruction() {
     assert(parse_stake_instructions(&instruction, &header, &info) == 0);
 }
 
-void test_parse_stake_instruction_kind() {
+void test_parse_stake_instruction_kind(void) {
     enum StakeInstructionKind kind;
     uint8_t buf[] = {0, 0, 0, 0};
     Parser parser = {buf, ARRAY_LEN(buf)};
@@ -204,7 +204,7 @@ void test_parse_stake_instruction_kind() {
     assert(parse_stake_instruction_kind(&parser, &kind) == 1);
 }
 
-void test_parse_stake_authorize_enum() {
+void test_parse_stake_authorize_enum(void) {
     enum StakeAuthorize authorize;
     uint8_t buf[] = {0, 0, 0, 0};
     Parser parser = {buf, ARRAY_LEN(buf)};
@@ -233,7 +233,7 @@ void test_parse_stake_authorize_enum() {
     assert(parse_stake_authorize(&parser, &authorize) == 1);
 }
 
-void test_parse_stake_lockup_args() {
+void test_parse_stake_lockup_args(void) {
     uint8_t buf[] = {
         // All None
         0x00,
@@ -317,7 +317,7 @@ void test_parse_stake_lockup_args() {
     assert(memcmp(lockup.custodian, &custodian2, sizeof(Pubkey)) == 0);
 }
 
-void test_parse_stake_lockup_checked_args() {
+void test_parse_stake_lockup_checked_args(void) {
     uint8_t buf[] = {
         // All None
         0x00,
@@ -387,7 +387,7 @@ void test_parse_stake_lockup_checked_args() {
     assert(lockup.epoch == 5);
 }
 
-int main() {
+int main(void) {
     test_parse_delegate_stake_instructions();
     test_parse_stake_initialize_instruction();
     test_parse_stake_instruction_kind();

--- a/system_instruction_test.c
+++ b/system_instruction_test.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <assert.h>
 
-void test_parse_system_transfer_instructions() {
+void test_parse_system_transfer_instructions(void) {
     uint8_t message[] = {1,   0,   1,   3,   171, 88,  202, 32,  185, 160, 182, 116, 130, 185, 73,
                          48,  13,  216, 170, 71,  172, 195, 165, 123, 87,  70,  130, 219, 5,   157,
                          240, 187, 26,  191, 158, 218, 204, 241, 115, 109, 41,  173, 110, 48,  24,
@@ -32,7 +32,7 @@ void test_parse_system_transfer_instructions() {
     assert(memcmp(fee_payer_pubkey, info.transfer.from, PUBKEY_SIZE) == 0);
 }
 
-void test_parse_system_transfer_instructions_with_payer() {
+void test_parse_system_transfer_instructions_with_payer(void) {
     uint8_t message[] = {2,   0,   1,   3,   204, 241, 115, 109, 41,  173, 110, 48,  24,  113, 210,
                          213, 163, 78,  1,   112, 146, 114, 235, 220, 96,  185, 184, 85,  163, 27,
                          124, 48,  54,  250, 233, 54,  171, 88,  202, 32,  185, 160, 182, 116, 130,
@@ -59,7 +59,7 @@ void test_parse_system_transfer_instructions_with_payer() {
     assert(memcmp(fee_payer_pubkey, info.transfer.to, PUBKEY_SIZE) == 0);
 }
 
-void test_parse_system_advance_nonce_account_instruction() {
+void test_parse_system_advance_nonce_account_instruction(void) {
     uint8_t message[] = {
         1,   1,   2,  4,   18,  67,  85,  168, 124, 173, 88,  142, 77,  171, 80,  178, 8,   218,
         230, 68,  85, 231, 39,  54,  184, 42,  162, 85,  172, 139, 54,  173, 194, 7,   64,  250,
@@ -116,7 +116,7 @@ void test_parse_system_advance_nonce_account_instruction() {
     assert(num_kinds == 3);
 }
 
-void test_system_create_account_with_seed_instruction() {
+void test_system_create_account_with_seed_instruction(void) {
 #define FROM_PUBKEY BYTES32_BS58_2
 #define TO_PUBKEY   BYTES32_BS58_3
 #define BASE_PUBKEY BYTES32_BS58_4
@@ -205,7 +205,7 @@ void test_system_create_account_with_seed_instruction() {
     assert(parse_system_instructions(&instruction, &header, &info) == 0);
 }
 
-void test_process_system_transfer() {
+void test_process_system_transfer(void) {
     uint8_t message[] = {1,   0,   1,   3,   171, 88,  202, 32,  185, 160, 182, 116, 130, 185, 73,
                          48,  13,  216, 170, 71,  172, 195, 165, 123, 87,  70,  130, 219, 5,   157,
                          240, 187, 26,  191, 158, 218, 204, 241, 115, 109, 41,  173, 110, 48,  24,
@@ -241,7 +241,7 @@ void test_process_system_transfer() {
     assert_string_equal(G_transaction_summary_text, "0.000000042 SOL");
 }
 
-void test_parse_system_instruction_kind() {
+void test_parse_system_instruction_kind(void) {
     enum SystemInstructionKind kind;
     uint8_t buf[] = {0, 0, 0, 0};
     Parser parser = {buf, ARRAY_LEN(buf)};
@@ -324,7 +324,7 @@ void test_parse_system_instruction_kind() {
     assert(parse_system_instruction_kind(&parser, &kind) == 1);
 }
 
-int main() {
+int main(void) {
     test_parse_system_transfer_instructions();
     test_parse_system_transfer_instructions_with_payer();
     test_parse_system_advance_nonce_account_instruction();

--- a/transaction_summary.c
+++ b/transaction_summary.c
@@ -92,7 +92,7 @@ static TransactionSummary G_transaction_summary;
 char G_transaction_summary_title[TITLE_SIZE];
 char G_transaction_summary_text[TEXT_BUFFER_LENGTH];
 
-void transaction_summary_reset() {
+void transaction_summary_reset(void) {
     memzero(&G_transaction_summary, sizeof(TransactionSummary));
     memzero(&G_transaction_summary_title, TITLE_SIZE);
     memzero(&G_transaction_summary_text, TEXT_BUFFER_LENGTH);
@@ -109,27 +109,27 @@ static SummaryItem* summary_item_as_unused(SummaryItem* item) {
     return NULL;
 }
 
-SummaryItem* transaction_summary_primary_item() {
+SummaryItem* transaction_summary_primary_item(void) {
     SummaryItem* item = &G_transaction_summary.primary;
     return summary_item_as_unused(item);
 }
 
-SummaryItem* transaction_summary_fee_payer_item() {
+SummaryItem* transaction_summary_fee_payer_item(void) {
     SummaryItem* item = &G_transaction_summary.fee_payer;
     return summary_item_as_unused(item);
 }
 
-SummaryItem* transaction_summary_nonce_account_item() {
+SummaryItem* transaction_summary_nonce_account_item(void) {
     SummaryItem* item = &G_transaction_summary.nonce_account;
     return summary_item_as_unused(item);
 }
 
-SummaryItem* transaction_summary_nonce_authority_item() {
+SummaryItem* transaction_summary_nonce_authority_item(void) {
     SummaryItem* item = &G_transaction_summary.nonce_authority;
     return summary_item_as_unused(item);
 }
 
-SummaryItem* transaction_summary_general_item() {
+SummaryItem* transaction_summary_general_item(void) {
     for (size_t i = 0; i < NUM_GENERAL_ITEMS; i++) {
         SummaryItem* item = &G_transaction_summary.general[i];
         if (!is_summary_item_used(item)) {

--- a/transaction_summary_test.c
+++ b/transaction_summary_test.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-void test_summary_item_setters() {
+void test_summary_item_setters(void) {
     SummaryItem item;
 
     summary_item_set_amount(&item, "amount", 42);
@@ -65,7 +65,7 @@ void test_summary_item_setters() {
     assert(item.i64 == 42);
 }
 
-void test_summary_item_as_unused() {
+void test_summary_item_as_unused(void) {
     SummaryItem item;
 
     item.kind = SummaryItemNone;
@@ -99,7 +99,7 @@ void test_summary_item_as_unused() {
     assert(summary_item_as_unused(&item) == NULL);
 }
 
-void test_transaction_summary_reset() {
+void test_transaction_summary_reset(void) {
     memset(&G_transaction_summary, 1, sizeof(TransactionSummary));
     memset(G_transaction_summary_title, 1, TITLE_SIZE);
     memset(G_transaction_summary_text, 1, TEXT_BUFFER_LENGTH);
@@ -129,7 +129,7 @@ void test_transaction_summary_reset() {
     }
 }
 
-void test_transaction_summary_item_getters() {
+void test_transaction_summary_item_getters(void) {
     SummaryItem* item;
 
     assert((item = transaction_summary_primary_item()) != NULL);
@@ -161,7 +161,7 @@ void test_transaction_summary_item_getters() {
         assert_string_equal(G_transaction_summary_text, text);      \
     } while (0)
 
-void test_transaction_summary_update_display_for_item() {
+void test_transaction_summary_update_display_for_item(void) {
     SummaryItem item;
 
     item.kind = SummaryItemNone;
@@ -245,7 +245,7 @@ void test_transaction_summary_update_display_for_item() {
         assert_transaction_summary_display(title, "42");            \
     } while (0)
 
-void test_transaction_summary_display_item() {
+void test_transaction_summary_display_item(void) {
     transaction_summary_reset();
 
     display_item_test_helper(primary, 0);
@@ -275,7 +275,7 @@ void test_transaction_summary_display_item() {
         }                                                               \
     } while (0)
 
-void test_transaction_summary_finalize() {
+void test_transaction_summary_finalize(void) {
     enum SummaryItemKind kinds[MAX_TRANSACTION_SUMMARY_ITEMS];
     size_t num_kinds;
     SummaryItem* item;
@@ -345,7 +345,7 @@ void test_transaction_summary_finalize() {
     assert_kinds_array(kinds, num_kinds);
 }
 
-void test_repro_unrecognized_format_reverse_nav_hash_corruption_bug() {
+void test_repro_unrecognized_format_reverse_nav_hash_corruption_bug(void) {
     SummaryItem* item;
     const char* primary_title = "Unrecognized";
     const char* primary_text = "format";
@@ -392,7 +392,7 @@ void test_repro_unrecognized_format_reverse_nav_hash_corruption_bug() {
     assert_transaction_summary_display(primary_title, primary_text);
 }
 
-int main() {
+int main(void) {
     test_summary_item_setters();
     test_summary_item_as_unused();
 

--- a/vote_instruction_test.c
+++ b/vote_instruction_test.c
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-void test_parse_vote_instruction_kind() {
+void test_parse_vote_instruction_kind(void) {
     enum VoteInstructionKind kind;
     uint8_t buf[] = {0, 0, 0, 0};
     Parser parser = {buf, ARRAY_LEN(buf)};
@@ -67,7 +67,7 @@ void test_parse_vote_instruction_kind() {
     assert(parse_vote_instruction_kind(&parser, &kind) == 1);
 }
 
-void test_parse_vote_authorize_enum() {
+void test_parse_vote_authorize_enum(void) {
     enum VoteAuthorize authorize;
     uint8_t buf[] = {0, 0, 0, 0};
     Parser parser = {buf, ARRAY_LEN(buf)};
@@ -96,7 +96,7 @@ void test_parse_vote_authorize_enum() {
     assert(parse_vote_authorize(&parser, &authorize) == 1);
 }
 
-int main() {
+int main(void) {
     test_parse_vote_instruction_kind();
     test_parse_vote_authorize_enum();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated all test and main function declarations to explicitly specify that they take no arguments, improving code clarity and consistency. No changes were made to test logic or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->